### PR TITLE
Remove console.log decodedToken and show cookies

### DIFF
--- a/lib/use-cases/Authorizer.js
+++ b/lib/use-cases/Authorizer.js
@@ -31,7 +31,7 @@ module.exports = function(options) {
           extractTokenFromCookieHeader(event) ||
           extractTokenFromUrl(event);
         const decodedToken = decodeToken(token, jwtSecret);
-        console.log(decodedToken);
+
         if (
           token &&
           decodedToken &&

--- a/lib/use-cases/ExtractTokenFromCookieHeader.js
+++ b/lib/use-cases/ExtractTokenFromCookieHeader.js
@@ -3,5 +3,6 @@ const cookie = require("cookie");
 module.exports = function extractTokenFromCookieHeader(e) {
   if (!(e.headers && e.headers.Cookie)) return null;
   const cookies = cookie.parse(e.headers.Cookie);
+  console.log(cookies);
   return cookies["hackneyToken"];
 };


### PR DESCRIPTION
## Context
We want to check if the cookies are being passed over when redirecting from the staging URL

## Changes proposed in this pull request
Add console log when fetching cookies
