### PR TITLE
Look up cookies case-insensitive

### DIFF
--- a/lib/use-cases/ExtractTokenFromCookieHeader.js
+++ b/lib/use-cases/ExtractTokenFromCookieHeader.js
@@ -1,7 +1,9 @@
 const cookie = require('cookie');
 
 module.exports = function extractTokenFromCookieHeader(e) {
-  if (!(e.headers && e.headers.Cookie)) return null;
-  const cookies = cookie.parse(e.headers.Cookie);
-  return cookies['hackneyToken'];
+  if (!e.headers) return null;
+  const cookies = e.headers.Cookie || e.headers.cookie;
+  if (!cookies) return null;
+  const parsedCookies = cookie.parse(cookies);
+  return parsedCookies['hackneyToken'];
 };

--- a/test/use-cases/ExtractTokenFromCookieHeader.test.js
+++ b/test/use-cases/ExtractTokenFromCookieHeader.test.js
@@ -14,4 +14,12 @@ describe('ExtractTokenFromCookieHeader', function() {
 
     expect(result).toBe('THISISATOKEN1234');
   });
+
+  it('can find the cookie case-insensitive', async function() {
+    const result = extractTokenFromCookieHeader({
+      headers: { cookie: 'hackneyToken=THISISATOKEN1234' }
+    });
+
+    expect(result).toBe('THISISATOKEN1234');
+  });
 });


### PR DESCRIPTION
## Context
We experienced issues when cookies were lower-case so they did not get picked up

## Changes proposed in this pull request
- Find cookies case-insensitive 
