### PR TITLE
Add GetTokenPayload use-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const authoriser = require('node-lambda-authorizer'){
     allowedGroups: process.env.ALLOWEDGROUP.split(",")
 };
 
-exports.handler = authoriser;
+exports.handler = authoriser.handler;
 ```
 
 ## CI

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const Authorizer = require('./lib/use-cases/Authorizer');
+const GetTokenPayload = require('./lib/use-cases/GetTokenPayload');
 
 module.exports = function(config) {
   const authorizer = new Authorizer({
@@ -6,7 +7,13 @@ module.exports = function(config) {
     allowedGroups: config.allowedGroups
   });
 
-  return async event => {
+  const getTokenPayload = new GetTokenPayload({
+    jwtSecret: config.jwtSecret
+  });
+
+  const handler = async event => {
     return authorizer.execute(event);
   };
+
+  return { handler, getTokenPayload };
 };

--- a/lib/use-cases/GetTokenPayload.js
+++ b/lib/use-cases/GetTokenPayload.js
@@ -1,0 +1,20 @@
+const extractTokenFromAuthHeader = require('./ExtractTokenFromAuthHeader');
+const extractTokenFromCookieHeader = require('./ExtractTokenFromCookieHeader');
+const extractTokenFromUrl = require('./ExtractTokenFromUrl');
+const decodeToken = require('./DecodeToken');
+
+module.exports = function(options) {
+  const jwtSecret = options.jwtSecret;
+
+  return event => {
+    const token =
+      extractTokenFromAuthHeader(event) ||
+      extractTokenFromCookieHeader(event) ||
+      extractTokenFromUrl(event);
+    try {
+      return decodeToken(token, jwtSecret);
+    } catch (err) {
+      return false;
+    }
+  };
+};

--- a/test/use-cases/GetTokenPayload.test.js
+++ b/test/use-cases/GetTokenPayload.test.js
@@ -1,0 +1,30 @@
+const GetTokenPayload = require('../../lib/use-cases/GetTokenPayload');
+const jwt = require('jsonwebtoken');
+
+describe('GetTokenPayload', function() {
+  it('returns null if the request does not have the right secrets', async function() {
+    const jwtSecret = 'secret';
+    const getTokenPayload = new GetTokenPayload({
+      jwtSecret: jwtSecret
+    });
+    expect(getTokenPayload({})).toBe(false);
+  });
+
+  it('returns the decoded token if the request have the right secrets', async function() {
+    const jwtSecret = 'secret';
+    const getTokenPayload = new GetTokenPayload({
+      jwtSecret: jwtSecret
+    });
+
+    const token = { token: 'super-secret-token', groups: ['Friends'] };
+    const encryptedToken = jwt.sign(token, jwtSecret);
+
+    expect(
+      getTokenPayload({
+        type: 'TOKEN',
+        headers: { Authorization: `Bearer ${encryptedToken}` },
+        methodArn: 'arn:aws:execute-api:{dummy}'
+      }).token
+    ).toContain('secret');
+  });
+});


### PR DESCRIPTION
## Context
We want to be able to get the decoded token from the authorizer

## Changes proposed in this pull request
- Add a GetTokenPayload use-case and update the `index.js` 
- Update Readme with the following change:
Initialize the service with your secret and user groups in authorizer file e.g: `authorizer.js`

```
const authoriser = require('node-lambda-authorizer'){
    jwtSecret: process.env.JWTSecret,
    allowedGroups: process.env.ALLOWEDGROUP.split(",")
};

exports.handler = authoriser.handler;
```
