### PR TITLE
Return Not Allowed when a user with a valid token is not in the allowed groups

### DIFF
--- a/lib/use-cases/Authorizer.js
+++ b/lib/use-cases/Authorizer.js
@@ -16,11 +16,8 @@ module.exports = function(options) {
     );
   };
 
-  const userIsAllowed = token => {
-    const decodedToken = decodeToken(token, jwtSecret);
-    return (
-      decodedToken && userInAllowedGroup(decodedToken.groups, allowedGroups)
-    );
+  const userIsAllowed = decodedToken => {
+    return userInAllowedGroup(decodedToken.groups, allowedGroups);
   };
 
   const allow = resource => {
@@ -43,10 +40,10 @@ module.exports = function(options) {
     execute: async event => {
       try {
         const token = getToken(event);
-        if (userIsAllowed(token)) {
-          return allow(event.methodArn);
-        }
-        return 'Unauthorized';
+        const decodedToken = decodeToken(token, jwtSecret);
+        if (!decodedToken) return 'Unauthorized';
+        if (!userIsAllowed(decodedToken)) return 'Not Allowed';
+        return allow(event.methodArn);
       } catch (err) {
         console.log(err);
       }

--- a/test/use-cases/Authorizer.test.js
+++ b/test/use-cases/Authorizer.test.js
@@ -14,6 +14,28 @@ describe('Authorizer', function() {
     expect(result).toBe('Unauthorized');
   });
 
+  it('returns "not allowed" if the token does not include the allowed group', async function() {
+    const jwtSecret = 'secret';
+    const allowedGroups = ['Friends'];
+    const authorizer = new Authorizer({
+      jwtSecret: jwtSecret,
+      allowedGroups: allowedGroups
+    });
+
+    const token = jwt.sign(
+      { token: 'super-secret-token', groups: ['Not in the group'] },
+      jwtSecret
+    );
+
+    var result = await authorizer.execute({
+      type: 'TOKEN',
+      headers: { Authorization: `Bearer ${token}` },
+      methodArn: 'arn:aws:execute-api:{dummy}'
+    });
+
+    expect(result).toBe('Not Allowed');
+  });
+
   it('allows a request that have the right secrets', async function() {
     const jwtSecret = 'secret';
     const allowedGroups = ['Friends'];


### PR DESCRIPTION
## Context
We want to be able to differentiate between unauthorized users and uses with a valid token, but not in the allowed groups
## Changes proposed in this pull request
Add a new response `'Not Allowed` to authorizer to when a user is not in the allowed groups

